### PR TITLE
feat: add retry mechanism to http client

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -129,7 +129,7 @@ func (c *Client) doRequest(method, path string, body []byte) (*http.Response, er
 			return err
 		}
 
-		if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusInternalServerError {
 			return fmt.Errorf("non-ok response from api: %s", resp.Status)
 		}
 


### PR DESCRIPTION
when running as a job it would be bennefictial to have a retry logic in cases when the API might be down or slow to respond because of heavy load so we don't fail the job on a single error