### PR TITLE
fix: request retries and response handling

### DIFF
--- a/internal/accession/accession.go
+++ b/internal/accession/accession.go
@@ -64,7 +64,7 @@ var accessionCmd = &cobra.Command{
 			slog.Info("dry run enabled, no accession ids will be created")
 			return nil
 		}
-		accessionIDs, err := postAccessionIDs(api, paths, userID, datasetFolder)
+		accessionIDs, err := postAccessionIDs(api, paths, userID)
 
 		for _, accessionID := range accessionIDs {
 			if _, err := file.WriteString(accessionID + "\n"); err != nil {
@@ -95,7 +95,7 @@ func Run(api client.APIClient, db database.PostgresDb, datasetFolder string, use
 	}
 
 	paths := getPathsForAccessionIDs(files)
-	accessionIDs, err := postAccessionIDs(api, paths, userID, datasetFolder)
+	accessionIDs, err := postAccessionIDs(api, paths, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func getPathsForAccessionIDs(files []models.FileInfo) []string {
 	return paths
 }
 
-func postAccessionIDs(api client.APIClient, paths []string, userID string, datasetFolder string) ([]string, error) {
+func postAccessionIDs(api client.APIClient, paths []string, userID string) ([]string, error) {
 	var accessionIDs []string
 	for _, filepath := range paths {
 		accessionID, err := generateAccessionID()
@@ -134,14 +134,13 @@ func postAccessionIDs(api client.APIClient, paths []string, userID string, datas
 			return accessionIDs, err
 		}
 
-		resp, err := api.PostFileAccession(payload)
+		_, err = api.PostFileAccession(payload)
 		if err != nil {
 			if errors.Is(err, io.ErrUnexpectedEOF) {
 				continue
 			}
 			return accessionIDs, err
 		}
-		defer resp.Body.Close() //nolint:errcheck
 		accessionIDs = append(accessionIDs, accessionID)
 	}
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -61,7 +61,7 @@ func New(cfg *config.Config) (*Client, error) {
 	return client, nil
 }
 
-func (c *Client) GetUsersFilesWithPrefix() (*http.Response, error) {
+func (c *Client) GetUsersFilesWithPrefix() ([]byte, error) {
 	basePath := fmt.Sprintf("users/%s/files", c.userID)
 
 	u, err := url.Parse(basePath)
@@ -77,52 +77,52 @@ func (c *Client) GetUsersFilesWithPrefix() (*http.Response, error) {
 }
 
 func (c *Client) GetUsersFiles() ([]models.FileInfo, error) {
-	resp, err := c.doRequest("GET", fmt.Sprintf("users/%s/files", c.userID), nil)
+	respBody, err := c.doRequest("GET", fmt.Sprintf("users/%s/files", c.userID), nil)
 	if err != nil {
 		return nil, err
 	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
 
 	var files []models.FileInfo
-	err = json.Unmarshal(body, &files)
+	err = json.Unmarshal(respBody, &files)
 	if err != nil {
 		return nil, err
 	}
 	return files, nil
 }
 
-func (c *Client) PostFileIngest(payload []byte) (*http.Response, error) {
+func (c *Client) PostFileIngest(payload []byte) ([]byte, error) {
 	return c.doRequest("POST", "file/ingest", payload)
 }
 
-func (c *Client) PostFileAccession(payload []byte) (*http.Response, error) {
+func (c *Client) PostFileAccession(payload []byte) ([]byte, error) {
 	return c.doRequest("POST", "file/accession", payload)
 }
 
-func (c *Client) PostDatasetCreate(payload []byte) (*http.Response, error) {
+func (c *Client) PostDatasetCreate(payload []byte) ([]byte, error) {
 	return c.doRequest("POST", "dataset/create", payload)
 }
 
-func (c *Client) doRequest(method, path string, body []byte) (*http.Response, error) {
+func (c *Client) doRequest(method, path string, body []byte) ([]byte, error) {
 	url := fmt.Sprintf("%s/%s", c.apiHost, path)
-	req, err := http.NewRequest(method, url, bytes.NewReader(body))
-	if err != nil {
-		slog.Warn("client new request err", "err", err)
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.accessToken)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	slog.Info("request", "method", method, "url", url)
 
-	var resp *http.Response
+	var (
+		resp *http.Response
+		err  error
+	)
+
 	err = backoff.Retry(func() error {
+		req, err := http.NewRequest(method, url, bytes.NewReader(body))
+		if err != nil {
+			slog.Warn("client new request err", "err", err)
+			return err
+		}
+
+		req.Header.Set("Authorization", "Bearer "+c.accessToken)
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		slog.Info("request", "method", method, "url", url)
+
 		resp, err = c.httpClient.Do(req)
 		if err != nil {
 			slog.Warn("client do err", "err", err)
@@ -130,10 +130,12 @@ func (c *Client) doRequest(method, path string, body []byte) (*http.Response, er
 		}
 
 		if resp.StatusCode == http.StatusInternalServerError {
+			resp.Body.Close()
 			return fmt.Errorf("non-ok response from api: %s", resp.Status)
 		}
 
 		return nil
+
 	}, backoff.NewExponentialBackOff())
 
 	if err != nil {
@@ -141,8 +143,20 @@ func (c *Client) doRequest(method, path string, body []byte) (*http.Response, er
 		return nil, err
 	}
 
-	slog.Info("response", "status", resp.Status)
-	return resp, nil
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("non-ok response: %s", resp.Status)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		slog.Error("could not read response body", "err", err)
+		return nil, err
+	}
+
+	slog.Info("respone", "status", resp.Status, "code", resp.StatusCode)
+	return responseBody, nil
 }
 
 func (c *Client) WaitForAccession(target int, interval time.Duration, timeout time.Duration) ([]string, error) {

--- a/internal/client/client_interface.go
+++ b/internal/client/client_interface.go
@@ -1,13 +1,11 @@
 package client
 
 import (
-	"net/http"
-
 	"github.com/NBISweden/submitter/internal/models"
 )
 
 type APIClient interface {
 	GetUsersFiles() ([]models.FileInfo, error)
-	PostFileIngest([]byte) (*http.Response, error)
-	PostFileAccession(payload []byte) (*http.Response, error)
+	PostFileIngest([]byte) ([]byte, error)
+	PostFileAccession(payload []byte) ([]byte, error)
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1,10 +1,7 @@
 package ingest
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"net/http"
 	"testing"
 
 	"github.com/NBISweden/submitter/internal/models"
@@ -12,7 +9,7 @@ import (
 
 type mockClient struct {
 	FilesToReturn []models.FileInfo
-	Response      *http.Response
+	Response      []byte
 	CallIndex     int
 }
 
@@ -20,11 +17,11 @@ func (m *mockClient) GetUsersFiles() ([]models.FileInfo, error) {
 	return m.FilesToReturn, nil
 }
 
-func (m *mockClient) PostFileIngest(data []byte) (*http.Response, error) {
+func (m *mockClient) PostFileIngest(data []byte) ([]byte, error) {
 	return m.Response, nil
 }
 
-func (m *mockClient) PostFileAccession(payload []byte) (*http.Response, error) {
+func (m *mockClient) PostFileAccession(payload []byte) ([]byte, error) {
 	return m.Response, nil
 }
 
@@ -36,7 +33,7 @@ func setup(userID string, datasetFolder string) *mockClient {
 			{InboxPath: fmt.Sprintf("/%s/PRIVATE/%s/file4.c4gh", userID, datasetFolder), Status: "uploaded"},
 			{InboxPath: fmt.Sprintf("/%s/%s/file5.c4gh", userID, datasetFolder), Status: "error"},
 		},
-		Response: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString("ok"))},
+		Response: []byte("ok"),
 	}
 	return mock
 }


### PR DESCRIPTION
- Recreate http requests on each retry to avoid consumed bodies. Previously a single *http.Request was reused across retries which caused to content body to be consumed and never recreated during retry, which led to `ContentLength with Body length 0` errors from the sda api.

- Rplace the deferred closes inside loops with an inline func to ensure each response is drained and closed before next iteration