### PR TITLE
Fix email template

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,29 +8,30 @@ import (
 )
 
 type Config struct {
-	DatasetFolder     string `mapstructure:"DATASET_FOLDER"`
-	DatasetID         string `mapstructure:"DATASET_ID"`
-	UserID            string `mapstructure:"USER_ID"`
-	SslCaCert         string `mapstructure:"SSL_CA_CERT"`
-	Timeout           int    `mapstructure:"JOB_TIMEOUT"`
-	PollRate          int    `mapstructure:"JOB_POLL_RATE"`
-	ClientApiHost     string `mapstructure:"CLIENT_API_HOST"`
-	ClientAccessToken string `mapstructure:"CLIENT_ACCESS_TOKEN"`
-	DbHost            string `mapstructure:"DB_HOST"`
-	DbPort            int    `mapstructure:"DB_PORT"`
-	DbUser            string `mapstructure:"DB_USER"`
-	DbPassword        string `mapstructure:"DB_PASSWORD"`
-	DbName            string `mapstructure:"DB_NAME"`
-	DbSchema          string `mapstructure:"DB_SCHEMA"`
-	DbSslMode         string `mapstructure:"DB_SSL_MODE"`
-	DbClientCert      string `mapstructure:"DB_CLIENT_CERT"`
-	DbClientKey       string `mapstructure:"DB_CLIENT_KEY"`
-	MailAddress       string `mapstructure:"MAIL_ADDRESS"`
-	MailPassword      string `mapstructure:"MAIL_PASSWORD"`
-	MailSmtpHost      string `mapstructure:"MAIL_SMTP_HOST"`
-	MailSmtpPort      int    `mapstructure:"MAIL_SMTP_PORT"`
-	MailUploaderName  string `mapstructure:"MAIL_UPLOADER_NAME"`
-	MailUploader      string `mapstructure:"MAIL_UPLOADER"`
+	DatasetFolder                string `mapstructure:"DATASET_FOLDER"`
+	DatasetID                    string `mapstructure:"DATASET_ID"`
+	UserID                       string `mapstructure:"USER_ID"`
+	SslCaCert                    string `mapstructure:"SSL_CA_CERT"`
+	Timeout                      int    `mapstructure:"JOB_TIMEOUT"`
+	PollRate                     int    `mapstructure:"JOB_POLL_RATE"`
+	ClientApiHost                string `mapstructure:"CLIENT_API_HOST"`
+	ClientAccessToken            string `mapstructure:"CLIENT_ACCESS_TOKEN"`
+	DbHost                       string `mapstructure:"DB_HOST"`
+	DbPort                       int    `mapstructure:"DB_PORT"`
+	DbUser                       string `mapstructure:"DB_USER"`
+	DbPassword                   string `mapstructure:"DB_PASSWORD"`
+	DbName                       string `mapstructure:"DB_NAME"`
+	DbSchema                     string `mapstructure:"DB_SCHEMA"`
+	DbSslMode                    string `mapstructure:"DB_SSL_MODE"`
+	DbClientCert                 string `mapstructure:"DB_CLIENT_CERT"`
+	DbClientKey                  string `mapstructure:"DB_CLIENT_KEY"`
+	MailAddress                  string `mapstructure:"MAIL_ADDRESS"`
+	MailPassword                 string `mapstructure:"MAIL_PASSWORD"`
+	MailSmtpHost                 string `mapstructure:"MAIL_SMTP_HOST"`
+	MailSmtpPort                 int    `mapstructure:"MAIL_SMTP_PORT"`
+	MailUploaderName             string `mapstructure:"MAIL_UPLOADER_NAME"`
+	MailUploaderOrganizationName string `mapstructure:"MAIL_UPLOADER_ORGANIZATION_NAME"`
+	MailUploader                 string `mapstructure:"MAIL_UPLOADER"`
 }
 
 func NewConfig(configPath string) (*Config, error) {
@@ -85,6 +86,7 @@ func bindKeys(v *viper.Viper) {
 	v.BindEnv("MAIL_SMTP_HOST")
 	v.BindEnv("MAIL_SMTP_PORT")
 	v.BindEnv("MAIL_UPLOADER_NAME")
+	v.BindEnv("MAIL_UPLOADER_ORGANIZATION_NAME")
 	v.BindEnv("MAIL_UPLOADER")
 }
 

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -58,9 +58,10 @@ type Mail struct {
 }
 
 type TemplateData struct {
-	Uploader      string
-	DatasetID     string
-	DatasetFolder string
+	Uploader         string
+	OrganizationName string
+	DatasetID        string
+	DatasetFolder    string
 }
 
 type Notifiers struct {
@@ -79,9 +80,10 @@ func New(c *config.Config) *Mail {
 		password: c.MailPassword,
 		from:     c.MailAddress,
 		data: TemplateData{
-			Uploader:      c.MailUploaderName,
-			DatasetID:     c.DatasetID,
-			DatasetFolder: c.DatasetFolder,
+			Uploader:         c.MailUploaderName,
+			OrganizationName: c.MailUploaderOrganizationName,
+			DatasetID:        c.DatasetID,
+			DatasetFolder:    c.DatasetFolder,
 		},
 		lookup: map[string]Notifiers{
 			"Submitter": {

--- a/internal/mail/templates/notify-bigpicture.html
+++ b/internal/mail/templates/notify-bigpicture.html
@@ -11,6 +11,7 @@
       <li><strong>Uploader:</strong> {{.Uploader}}</li>
       <li><strong>Dataset ID:</strong> {{.DatasetID}}</li>
       <li><strong>Inbox Data Folder Name:</strong> {{.DatasetFolder}}</li>
+      <li><strong>Organization name:</strong> {{.OrganizationName}}</li>
     </ul>
 
     <p>

--- a/internal/mail/templates/notify-minttu.html
+++ b/internal/mail/templates/notify-minttu.html
@@ -11,6 +11,7 @@
       <li><strong>Uploader:</strong> {{.Uploader}}</li>
       <li><strong>Dataset ID:</strong> {{.DatasetID}}</li>
       <li><strong>Inbox Data Folder Name:</strong> {{.DatasetFolder}}</li>
+      <li><strong>Organization name:</strong> {{.OrganizationName}}</li>
     </ul>
 
     <p>


### PR DESCRIPTION
This PR fixes #31 

It uses `dataset_id` instead of `dataset_folder` in the email title and add `organization name` in the mail body for emails to CSC and Minttu.