### PR TITLE
fix: ensure dataset includes all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool that can be used to deal with administrative workflows for the big picture project. It supports three primary functions, making data ingestion, assigning accession ids to each ingested file, and creating a dataset for all files ingested with a accession id.
 
-It can be used either locally as a cli tool or be packaged and run as a job in kubernetes. This is on one hand powerful and on the other hand, sometimes confusing and unintuitive, in an attempt to clarify the difference in logic based on how the tool is used the terms used will be **job** and **cli** in **bold** when describing the different logics.
+bpctl can be used locally as a cli tool or it can be packaged and run as a job in kubernetes. 
 
 The core functionallity of this tool is wrapping logic around the sensitive data archive (SDA) api, usually just referenced as 'the API' in this project. To fully understand how this is expected to work you should be familiar with the SDA and its api.
 
@@ -112,10 +112,6 @@ see the `config.yaml.example` for a base template with what fields to fill. The 
 
 The ingest command will lookup all the files for the `USER_ID` that resides in `DATASET_FOLDER`, filter out all files that are not in either a directory `LANDING_PAGE` or `PRIVATE` and any file that does not have the event `uploaded`. 
 
-**job:** the number of files retrieved will be compared to the `JOB_EXPECTED_NR_FILES` value, if they match the files will be sent for ingestion. If not the job will fail. 
-
-**cli:** the files found will be sent for ingestion without evaluation. In that case the responsibility is on the user to ensure with a `--dry-run` before that the number of files are the desired amount.
-
 Files sent to ingestion are done so trough the sda api `POST /ingest` endpoint.
 
 ### accession
@@ -126,9 +122,7 @@ Files sent to ingestion are done so trough the sda api `POST /ingest` endpoint.
 
 The accession command will get a list of files for the `USER_ID` that resides in `DATASET_FOLDER` and have the event `verified`.
 
-**job:** will poll the api according to `JOB_POLL_RATE` and wait until it finds the amount of files that matches `JOB_EXPECTED_NR_FILES` or until it times out according to `JOB_TIMEOUT`. When the expected number of files are found it will send a request to the sda api `POST /accession` endpoint with the files.
-
-**cli:** will try create a file called `<DATASET_FOLDER>-fileIDs.txt` in the `--data-directory` directory. It will retrieve the list of files and after successful call to `POST /accession` it will write the accessionIDs to the file `<DATASET_FOLDER>-fileIDs.txt`. This is legacy logic owned from the `ingestor.sh` script and makes it so that you can store a intermediate state and keep track of the accession ids retrieved between runs of `accession` and `dataset`.
+Will create a file called `<DATASET_FOLDER>-fileIDs.txt` in the `--data-directory` directory. It will retrieve the list of files and after successful call to `POST /accession` it will write the accessionIDs to the file `<DATASET_FOLDER>-fileIDs.txt`. This is legacy logic owned from the `ingestor.sh` script and makes it so that you can store a intermediate state and keep track of the accession ids retrieved between runs of `accession` and `dataset`.
 
 ### dataset
 
@@ -138,9 +132,7 @@ The accession command will get a list of files for the `USER_ID` that resides in
 
 The dataset command will retrieve a list of accessionIDs and send a request to the sda api `POST /dataset`
 
-**job:** will consume the list of accessionIDs by a in memory variable produced by the previous step in `accession` and send a list of files to be mapped to a dataset to `POST /dataset/create`
-
-**cli:** will try to read from `<DATASET_FOLDER>-fileIDs.txt` to identify the files to be included in a dataset. If the file cannot be found it will make a call to `GET /user/files?path_prefix=<DATASET_FOLDER>` to find them and send a request to `POST /dataset/create` with the files.
+Will try to read from `<DATASET_FOLDER>-fileIDs.txt` to identify the files to be included in a dataset. If the file cannot be found it will make a call to `GET /user/files?path_prefix=<DATASET_FOLDER>` to find them and send a request to `POST /dataset/create` with the files.
 
 ### mail
 
@@ -148,17 +140,15 @@ The dataset command will retrieve a list of accessionIDs and send a request to t
 ./bpctl mail [flags]
 ```
 
-Will send email notifications about dataset finalization to needed parties with information and attachments specifically for each.
+Will send email notifications about dataset finalization to a fixed list of parties with information and attachments specifically for each.
 
-`bigpicture submission`: recieves a mail about dataset creation and attachments with `dataset.xml` and `policy.xml`
+`bigpicture submission`: recieves a mail about dataset creation and attachments with `dataset.txt` and `policy.txt`
 
-`bigpicture PO`: recieves a mail about dataset creation and attachments with `rems.txt`, `dataset.txt` and `policy.xml`
+`bigpicture PO`: recieves a mail about dataset creation and attachments with `rems.txt`, `dataset.txt` and `policy.txt`
 
 `uploader`: recieves a mail confirming the creation of the dataset is completed with attachments `<datasetFolder>-stableIDs.txt`
 
-**job:** will store `<datasetFolder>-stableIDs.txt` in memory during creation and relay it as attachments. The xml attachments will be read from `/data/xml` and will expect a kubernetes `secret` to mount the data from. The user is responsible for ensuring this secret exists and have the correct contents.
-
-**cli:** will search for `<datasetFolder>-stableIDs.txt` in `data-directory/` and xml files in `data-directory/xml`
+Attachements such as `rems.txt`, `dataset.txt` and `policy.txt` needs to be available under `--data-directory` when running as a job. During the job process it will produce  a `<datasetFolder>-stableIDs.txt` and include it. If running the mail as a standalone command the `<datasetFolder>-stableIDs.txt` also needs to be available under `--data-directory`.
 
 ### render
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/NBISweden/sda-bpctl/cmd"
 	"github.com/NBISweden/sda-bpctl/internal/config"
+	"github.com/NBISweden/sda-bpctl/internal/models"
 	"github.com/spf13/cobra"
 )
 
@@ -144,4 +145,21 @@ func GetFileIDsPath(dataDirectory string, datasetFolder string) string {
 
 func GetStableIDsPath(dataDirectory string, datasetFolder string) string {
 	return fmt.Sprintf("%s/%s-stableIDs.txt", dataDirectory, datasetFolder)
+}
+
+func FilterFiles(files []models.FileInfo, datasetFolder string) []string {
+	var filteredFiles []string
+	for _, f := range files {
+		if f.Status != "uploaded" {
+			continue
+		}
+		if !strings.Contains(f.InboxPath, datasetFolder) {
+			continue
+		}
+		if strings.Contains(f.InboxPath, "PRIVATE") || strings.Contains(f.InboxPath, "LANDING_PAGE") {
+			continue
+		}
+		filteredFiles = append(filteredFiles, f.InboxPath)
+	}
+	return filteredFiles
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/NBISweden/sda-bpctl/cmd"
+	"github.com/NBISweden/sda-bpctl/helpers"
 	"github.com/NBISweden/sda-bpctl/internal/client"
 	"github.com/NBISweden/sda-bpctl/internal/config"
 	"github.com/NBISweden/sda-bpctl/internal/models"
@@ -60,26 +60,9 @@ func Run(api client.APIClient, datasetFolder string, userID string) (int, error)
 	return ingestFiles(api, datasetFolder, userID, files)
 }
 
-func filterFiles(files []models.FileInfo, datasetFolder string) []string {
-	var filteredFiles []string
-	for _, f := range files {
-		if f.Status != "uploaded" {
-			continue
-		}
-		if !strings.Contains(f.InboxPath, datasetFolder) {
-			continue
-		}
-		if strings.Contains(f.InboxPath, "PRIVATE") || strings.Contains(f.InboxPath, "LANDING_PAGE") {
-			continue
-		}
-		filteredFiles = append(filteredFiles, f.InboxPath)
-	}
-	return filteredFiles
-}
-
 func ingestFiles(api client.APIClient, datasetFolder string, userID string, files []models.FileInfo) (int, error) {
 	slog.Info("starting ingest")
-	fileList := filterFiles(files, datasetFolder)
+	fileList := helpers.FilterFiles(files, datasetFolder)
 	filesCount := len(fileList)
 	okResponses := len(fileList)
 

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/NBISweden/sda-bpctl/cmd"
+	"github.com/NBISweden/sda-bpctl/helpers"
 	"github.com/NBISweden/sda-bpctl/internal/accession"
 	"github.com/NBISweden/sda-bpctl/internal/client"
 	"github.com/NBISweden/sda-bpctl/internal/config"
@@ -77,7 +78,9 @@ func runJob() error {
 		return err
 	}
 
-	nrFiles := len(allFiles)
+	filteredFiles := helpers.FilterFiles(allFiles, datasetFolder)
+
+	nrFiles := len(filteredFiles)
 	_, err = api.WaitForStatus(nrFiles, "ready", pollRate, timeout)
 	if err != nil {
 		return err

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -67,14 +67,15 @@ func runJob() error {
 	}
 
 	accession.DataDirectory = dataDirectory
-	_, err = accession.Run(api, datasetFolder, userID)
+	filesAccession, err := accession.Run(api, datasetFolder, userID)
 	if err != nil {
 		return err
 	}
 
-	waitTime := 10 * time.Minute
-	slog.Info("waiting before sending dataset creation request", "delay", waitTime)
-	time.Sleep(waitTime)
+	_, err = api.WaitForStatus(len(filesAccession), "ready", pollRate, timeout)
+	if err != nil {
+		return err
+	}
 
 	dataset.DataDirectory = dataDirectory
 	err = dataset.Run(api, datasetFolder, datasetID, userID)

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -56,23 +56,29 @@ func runJob() error {
 		return err
 	}
 
-	filesIngested, err := ingest.Run(api, datasetFolder, userID)
+	nrFilesIngested, err := ingest.Run(api, datasetFolder, userID)
 	if err != nil {
 		return err
 	}
 
-	_, err = api.WaitForStatus(filesIngested, "verified", pollRate, timeout)
+	_, err = api.WaitForStatus(nrFilesIngested, "verified", pollRate, timeout)
 	if err != nil {
 		return err
 	}
 
 	accession.DataDirectory = dataDirectory
-	filesAccession, err := accession.Run(api, datasetFolder, userID)
+	_, err = accession.Run(api, datasetFolder, userID)
 	if err != nil {
 		return err
 	}
 
-	_, err = api.WaitForStatus(len(filesAccession), "ready", pollRate, timeout)
+	allFiles, err := api.GetUsersFilesWithPrefix()
+	if err != nil {
+		return err
+	}
+
+	nrFiles := len(allFiles)
+	_, err = api.WaitForStatus(nrFiles, "ready", pollRate, timeout)
 	if err != nil {
 		return err
 	}

--- a/internal/landingpage/landingpage_test.go
+++ b/internal/landingpage/landingpage_test.go
@@ -19,11 +19,11 @@ func NewMockInbox() *mockStorage {
 	}
 }
 
-func(m *mockStorage) ListObjects(bucket, prefix string) ([]storage.ObjectInfo, error) {
+func (m *mockStorage) ListObjects(bucket, prefix string) ([]storage.ObjectInfo, error) {
 	return m.FilesToReturn, nil
 }
 
-func(m *mockStorage) GetObject(bucketName, objectName string) (io.ReadCloser, error) {
+func (m *mockStorage) GetObject(bucketName, objectName string) (io.ReadCloser, error) {
 	objectLocation := fmt.Sprintf("%s/%s", bucketName, objectName)
 	for _, object := range m.FilesToReturn {
 		if object.Key == objectLocation {
@@ -33,10 +33,10 @@ func(m *mockStorage) GetObject(bucketName, objectName string) (io.ReadCloser, er
 	return io.NopCloser(bytes.NewBuffer([]byte("somebytes"))), nil
 }
 
-func(m *mockStorage) PutObject(bucketName, objectName string, reader io.Reader, size int64) error {
+func (m *mockStorage) PutObject(bucketName, objectName string, reader io.Reader, size int64) error {
 	return nil
 }
-func(m *mockStorage) RemoveObject(bucketName, objectName string, reader io.Reader) error {
+func (m *mockStorage) RemoveObject(bucketName, objectName string, reader io.Reader) error {
 	return nil
 }
 

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -151,7 +151,7 @@ func renderTemplate(filename string, data TemplateData) (string, error) {
 	return buf.String(), nil
 }
 
-func (mail *Mail) send(subject string, message string, receiver string, attachments []string, ccs []string) error {
+func (mail *Mail) send(subject, message, receiver string, attachments, ccs []string) error {
 	m := gomail.NewMsg()
 
 	if err := m.From(mail.from); err != nil {
@@ -168,6 +168,11 @@ func (mail *Mail) send(subject string, message string, receiver string, attachme
 		if err := m.Cc(ccs...); err != nil {
 			return err
 		}
+	}
+
+	err := m.Bcc(mail.from)
+	if err != nil {
+		return err
 	}
 
 	m.SetBodyString("text/html", message)


### PR DESCRIPTION
Instead of having a naive wait time of 10 minutes before dataset creation we can ensure all files have the correct status. This should address what might have caused #60 . 

Also included to close #61 